### PR TITLE
Fix for dataset state after creating resource

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -22,7 +22,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
         _uploadName: null,
         _uploadedParts: null,
         _clickedBtn: null,
-        _redirect_url: null;
+        _redirect_url: null,
 
         initialize: function() {
             $.proxyAll(this, /_on/);
@@ -365,6 +365,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
             var data_dict = {
                 'uploadId': this._uploadId,
                 'id': this._resourceId,
+                'save_action': this._clickedBtn
             }
             this.sandbox.client.call(
                 'POST',

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -179,7 +179,7 @@ def finish_multipart(context, data_dict):
 
     h.check_access('cloudstorage_finish_multipart', data_dict)
     upload_id = toolkit.get_or_bust(data_dict, 'uploadId')
-    finish = data_dict.get('finish', False)
+    save_action = data_dict.get('save_action', False)
     upload = model.Session.query(MultipartUpload).get(upload_id)
     chunks = [
         (part.n, part.etag)
@@ -199,7 +199,7 @@ def finish_multipart(context, data_dict):
     upload.delete()
     upload.commit()
 
-    if finish:
+    if save_action and save_action == "go-metadata":
         try:
             res_dict = toolkit.get_action('resource_show')(
                 context.copy(), {'id': data_dict.get('id')})


### PR DESCRIPTION
When we create upload and create new resource at second step after creating dataset, datasets state is not changed to active one.

Reproduce:
1.Click on add new dataset.
2. Complete the form and click on Next stage.
3. Click on Upload and select a file.
4. Complete the form and click Finish.
5. Dataset will appear as draft.

To fix this, I've added new property in data_dict(save_action, similar to save_action in package.py), so finish logic will work as it was designed.