### PR TITLE
add url_type to multipart data

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -276,6 +276,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
             formData.url = file.name;
             formData.package_id = this.options.packageId;
             formData.size = file.size;
+            formData.url_type = 'upload';
             var action = formData.id ? 'resource_update' : 'resource_create';
             var url = this._form.attr('action') || window.location.href;
             this.sandbox.client.call(


### PR DESCRIPTION
This fix adds `url_type` into formData sent to server during multipart upload so that CKAN can generate correct url for new resource