### PR TITLE
Including Content-Type header in S3 signature

### DIFF
--- a/ckanext/cloudstorage/controller.py
+++ b/ckanext/cloudstorage/controller.py
@@ -44,7 +44,15 @@ class StorageController(base.BaseController):
             filename = os.path.basename(resource['url'])
 
         upload = uploader.get_resource_uploader(resource)
-        uploaded_url = upload.get_url_from_filename(resource['id'], filename)
+
+        # if the client requests with a Content-Type header (e.g. Text preview)
+        # we have to add the header to the signature
+        try:
+            content_type = getattr(c.pylons.request, "content_type", None)
+        except AttributeError:
+            content_type = None
+        uploaded_url = upload.get_url_from_filename(resource['id'], filename,
+                                                    content_type=content_type)
 
         # The uploaded file is missing for some reason, such as the
         # provider being down.

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -259,7 +259,7 @@ class ResourceCloudStorage(CloudStorage):
                 # outstanding lease.
                 return
 
-    def get_url_from_filename(self, rid, filename):
+    def get_url_from_filename(self, rid, filename, content_type=None):
         """
         Retrieve a publically accessible URL for the given resource_id
         and filename.
@@ -271,6 +271,7 @@ class ResourceCloudStorage(CloudStorage):
 
         :param rid: The resource ID.
         :param filename: The resource filename.
+        :param content_type: Optionally a Content-Type header.
 
         :returns: Externally accessible URL or None.
         """
@@ -303,13 +304,16 @@ class ResourceCloudStorage(CloudStorage):
                 self.driver_options['key'],
                 self.driver_options['secret']
             )
-            return s3_connection.generate_url(
-                expires_in=60 * 60,
-                method='GET',
-                bucket=self.container_name,
-                query_auth=True,
-                key=path
-            )
+
+            generate_url_params = {"expires_in": 60 * 60,
+                                   "method": "GET",
+                                   "bucket": self.container_name,
+                                   "query_auth": True,
+                                   "key": path}
+            if content_type:
+                generate_url_params['headers'] = {"Content-Type": content_type}
+
+            return s3_connection.generate_url(**generate_url_params)
 
         # Find the object for the given key.
         obj = self.container.get_object(path)


### PR DESCRIPTION
Fixes #28 
I didn't include any other headers, because I don't want to risk breaking anything. With this fix, the [text-view](http://docs.ckan.org/en/latest/maintaining/data-viewer.html#text-view) preview works for *JSON*/*GeoJSON* files stored on *S3*, that previously wouldn't work because the signature was calculated without the `Content-Type` header that is sent by the JavaScript code.