### PR TITLE
Implement get_path

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -11,6 +11,7 @@ from pylons import config
 from ckan import model
 from ckan.lib import munge
 import ckan.plugins as p
+from ckan.plugins.toolkit import get_action
 
 from libcloud.storage.types import Provider, ObjectDoesNotExistError
 from libcloud.storage.providers import get_driver
@@ -198,6 +199,12 @@ class ResourceCloudStorage(CloudStorage):
             rid,
             munge.munge_filename(filename)
         )
+
+    def get_path(self, resource_id):
+        resource = get_action('resource_show')({}, {'id': resource_id})
+        filename = resource['url'].rsplit('/', 1)[-1]
+
+        return self.get_url_from_filename(resource_id, filename)
 
     def upload(self, id, max_size=10):
         """


### PR DESCRIPTION
get_path is required interface in IUploader http://docs.ckan.org/en/2.8/extensions/plugin-interfaces.html#ckan.plugins.interfaces.IUploader.get_resource_uploader

Even though this extension itself does not use, it is required if some other extension interacts with resource_uploaders, for example ckanext-archiver does this. 