### PR TITLE
Add CKAN 2.8 support

### DIFF
--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -11,8 +11,15 @@ import ckan.plugins.toolkit as toolkit
 
 from ckanext.cloudstorage.storage import ResourceCloudStorage
 from ckanext.cloudstorage.model import MultipartUpload, MultipartPart
+from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
 log = logging.getLogger(__name__)
+
+
+def _get_underlying_file(wrapper):
+    if isinstance(wrapper, FlaskFileStorage):
+        return wrapper.stream
+    return wrapper.file
 
 
 def _get_max_multipart_lifetime():
@@ -152,7 +159,7 @@ def upload_multipart(context, data_dict):
             uploader, upload.name) + '?partNumber={0}&uploadId={1}'.format(
                 part_number, upload_id),
         method='PUT',
-        data=bytearray(part_content.file.read())
+        data=bytearray(_get_underlying_file(part_content).read())
     )
     if resp.status != 200:
         raise toolkit.ValidationError('Upload failed: part %s' % part_number)


### PR DESCRIPTION
CKAN 2.8 migrated api to flask and file handling was changed https://github.com/ckan/ckan/pull/3884. This PR ports the change to cloudstorage.

Without it the upload would error with the following log:

`Traceback (most recent call last):
  File "/usr/lib/ckan/default/src/ckan/ckan/views/api.py", line 288, in action
    result = function(context, request_data)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 464, in wrapped
    result = _action(context, data_dict, **kw)
  File "/vagrant/modules/ckanext-cloudstorage/ckanext/cloudstorage/logic/action/multipart.py", line 160, in upload_multipart
    data=bytearray(part_content.file.read())
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/werkzeug/datastructures.py", line 2745, in __getattr__
    return getattr(self.stream, name)
AttributeError: SpooledTemporaryFile instance has no attribute 'file'`