### PR TITLE
Support custom endpoint on S3 connection

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -299,10 +299,11 @@ class ResourceCloudStorage(CloudStorage):
                 )
             )
         elif self.can_use_advanced_aws and self.use_secure_urls:
-            from boto.s3.connection import S3Connection
+            from boto.s3.connection import S3Connection, NoHostProvided
             s3_connection = S3Connection(
                 self.driver_options['key'],
-                self.driver_options['secret']
+                self.driver_options['secret'],
+                host=self.driver_options.get('endpoint_url', NoHostProvided),
             )
 
             generate_url_params = {"expires_in": 60 * 60,


### PR DESCRIPTION
Add a parameter to allow custom S3 providers like [Wasabi](https://wasabi.com/)

Seems like a pretty simple change.