### PR TITLE
add missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'apache-libcloud==1.5'
+        'apache-libcloud==1.5',
+        'ckanapi>=1.0,<5'
     ],
     entry_points=(
         """


### PR DESCRIPTION
This library is required in https://github.com/TkTech/ckanext-cloudstorage/blob/5e5f1993b51779a67be2d07d7e229ebbb1961754/ckanext/cloudstorage/cli.py#L11 but it isn't installed with the package requirements.