### PR TITLE
Upgrade libcloud to 2.8.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'apache-libcloud==1.5',
+        'apache-libcloud==2.8.3',
         'ckanapi>=1.0,<5'
     ],
     entry_points=(


### PR DESCRIPTION
This implements:
 Upgrade libcloud to the latest release supporting python #53